### PR TITLE
Fix VMR download 403 by adding User-Agent header

### DIFF
--- a/taxmyphage/download_check.py
+++ b/taxmyphage/download_check.py
@@ -14,7 +14,7 @@ import subprocess
 import gzip
 import shutil
 from typing import List
-import wget
+from urllib.request import Request, urlopen
 from Bio import SeqIO
 
 from taxmyphage.utils import print_error, print_ok, create_folder
@@ -34,11 +34,19 @@ def download(url: str, output: str) -> None:
 
     Returns:
         None
+    
+    Note:
+        This function uses a user-agent header to mimic a browser request, which can help avoid issues with some servers that block non-browser requests.
     """
 
     try:
-        wget.download(url, output)
+        req = Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with urlopen(req) as response, open(output, "wb") as out_file:
+            shutil.copyfileobj(response, out_file)
+
+
         print(f"\n{url} downloaded successfully!")
+
     except Exception as e:
         print(f"An error occurred while downloading {url}: {e}")
         sys.exit()


### PR DESCRIPTION
### Proposed changes in this pull request

- [x] Bug :bug:
- [ ] Add tests :white_check_mark:
- [ ] Documentation or notebook change :memo:
- [ ] Removed code or file :fire:
- [ ] Dependency downgrade :arrow_down:
- [ ] Dependency upgrade :arrow_up:
- [x] Enhancement :art:

### This fixes or addresses the following GitHub issues:

- Ref: N/A

### Description of the Pull Request (PR):

The current implementation of `download()` relies on `wget.download()` to retrieve files. However, `wget` does not send a `User-Agent` header by default. When attempting to download the ICTV VMR file via https://ictv.global/vmr/current the server responds with HTTP 403, as the request is interpreted as coming from a non-browser client.

This PR replaces the use of `wget` with Python's standard library `urllib.request` and adds a browser-like `User-Agent` header. This allows the redirect from https://ictv.global/vmr/current to the actual VMR file to complete successfully.

Changes:
- Replaced `wget.download()` with `urllib.request` (Request, urlopen)
- Updated the `download()` function to include a `User-Agent` header
- Removed the `wget` dependency

The fix was tested locally and the VMR file downloads correctly without triggering the HTTP 403 error.

### Checkoff for all PRs:

- [x] I have read the [Guidelines for Contributing](https://github.com/amillard/tax_myPHAGE/blob/master/.github/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- [x] I have tested this PR locally, and it works as intended.
- [ ] I have added myself as a contributor to the [contributors's file](https://github.com/amillard/tax_myPHAGE/blob/master/CONTRIBUTORS.md)
- [x] This PR is ready for review and/or merge